### PR TITLE
have Azure DevOps target pb-dev branch

### DIFF
--- a/.azure/azure-pipeline.yml
+++ b/.azure/azure-pipeline.yml
@@ -2,6 +2,7 @@ trigger:
 - master
 - dev
 - features/*
+- pb-dev
 
 jobs:
 - job: Linux


### PR DESCRIPTION
Have local Azure DevOps target the `pb-dev` branch repository in my personal fork.